### PR TITLE
Add scraper for bfskinner.org free resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,53 @@
 # BFSkinner-scrape
-Web scraping tool for B.F. Skinner related content
+
+Command line scraper that crawls [bfskinner.org](https://www.bfskinner.org/) for
+links to freely available resources such as PDFs, audio, and other downloads.
+
+## Prerequisites
+
+- Python 3.12+
+- Recommended: create a virtual environment and install dependencies from
+  `requirements.txt`.
+
+## Installation
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Usage
+
+```bash
+python scrape.py --max-pages 300 --delay 1.0 --output data/free_resources.csv \
+  --json data/free_resources.json
+```
+
+The script performs a breadth-first crawl of `bfskinner.org`, recording resource
+links that either point to downloadable assets (PDFs, audio, etc.) or pages with
+keywords indicating free materials. Results are written to CSV and optionally
+JSON files.
+
+> **Note**
+> Access to external websites may be restricted in certain network
+> environments. If the crawl logs proxy-related errors (e.g. 403 responses), try
+> running the script from a network with unrestricted outbound HTTPS access.
+
+## Development
+
+- `scrape.py` exposes the CLI entry point.
+- Core scraping logic lives in `bfskinner_scraper/scraper.py`.
+- The scraper returns a list of `ResourceRecord` dataclasses that can be easily
+  converted to pandas DataFrames via `BFSkinnerScraper.to_dataframe`.
+
+## Exporting to Pandas
+
+```python
+from bfskinner_scraper import BFSkinnerScraper
+
+scraper = BFSkinnerScraper(max_pages=150)
+resources = scraper.crawl()
+df = scraper.to_dataframe(resources)
+df.to_excel("data/free_resources.xlsx", index=False)
+```

--- a/bfskinner_scraper/__init__.py
+++ b/bfskinner_scraper/__init__.py
@@ -1,0 +1,5 @@
+"""B.F. Skinner resource scraping utilities."""
+
+from .scraper import BFSkinnerScraper, ResourceRecord
+
+__all__ = ["BFSkinnerScraper", "ResourceRecord"]

--- a/bfskinner_scraper/scraper.py
+++ b/bfskinner_scraper/scraper.py
@@ -1,0 +1,238 @@
+"""Scraper implementation for bfskinner.org free resources."""
+from __future__ import annotations
+
+import logging
+import time
+from collections import deque
+from dataclasses import dataclass, asdict
+from typing import Iterable, Iterator, List, Optional, Set
+from urllib.parse import urljoin, urlparse
+
+import requests
+from bs4 import BeautifulSoup
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ResourceRecord:
+    """Representation of a free resource discovered on the site."""
+
+    page_url: str
+    resource_url: str
+    resource_title: str
+    resource_type: str
+    page_title: Optional[str] = None
+    description: Optional[str] = None
+
+    def as_dict(self) -> dict:
+        """Return a dictionary representation suitable for serialization."""
+        return asdict(self)
+
+
+class BFSkinnerScraper:
+    """Crawler that extracts free resources from bfskinner.org.
+
+    The scraper performs a bounded breadth-first crawl across the domain, looking
+    for downloadable assets (PDFs, audio/video files) and textual references to
+    free resources.
+    """
+
+    RESOURCE_EXTENSIONS: Set[str] = {
+        ".pdf",
+        ".doc",
+        ".docx",
+        ".ppt",
+        ".pptx",
+        ".xls",
+        ".xlsx",
+        ".zip",
+        ".mp3",
+        ".mp4",
+        ".wav",
+        ".m4a",
+    }
+
+    KEYWORD_HINTS: Set[str] = {
+        "download",
+        "free",
+        "resource",
+        "handout",
+        "worksheet",
+        "guide",
+        "ebook",
+        "podcast",
+        "video",
+        "audio",
+        "pdf",
+    }
+
+    DEFAULT_HEADERS = {
+        "User-Agent": (
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/117.0 Safari/537.36"
+        )
+    }
+
+    def __init__(
+        self,
+        base_url: str = "https://www.bfskinner.org/",
+        *,
+        session: Optional[requests.Session] = None,
+        max_pages: int = 200,
+        request_delay: float = 0.5,
+        timeout: int = 30,
+    ) -> None:
+        self.base_url = base_url.rstrip("/") + "/"
+        self.session = session or requests.Session()
+        self.session.headers.update(self.DEFAULT_HEADERS)
+        self.max_pages = max_pages
+        self.request_delay = request_delay
+        self.timeout = timeout
+        self._visited: Set[str] = set()
+
+    def crawl(self) -> List[ResourceRecord]:
+        """Execute the crawl starting at ``base_url``."""
+        queue: deque[str] = deque([self.base_url])
+        resources: List[ResourceRecord] = []
+
+        while queue and len(self._visited) < self.max_pages:
+            url = queue.popleft()
+            if url in self._visited:
+                continue
+            logger.debug("Fetching %s", url)
+            try:
+                html = self._fetch(url)
+            except requests.RequestException as exc:
+                logger.warning("Failed to fetch %s: %s", url, exc)
+                continue
+
+            self._visited.add(url)
+            if html is None:
+                continue
+
+            soup = BeautifulSoup(html, "html.parser")
+            page_title = self._extract_page_title(soup)
+            resources.extend(self._extract_resources(url, page_title, soup))
+
+            for link in self._extract_internal_links(url, soup):
+                if link not in self._visited and link not in queue:
+                    queue.append(link)
+
+            if self.request_delay:
+                time.sleep(self.request_delay)
+
+        return resources
+
+    # ------------------------------------------------------------------
+    def _fetch(self, url: str) -> Optional[str]:
+        response = self.session.get(url, timeout=self.timeout)
+        if not response.ok:
+            logger.warning("Non-200 response for %s: %s", url, response.status_code)
+            return None
+        if "text/html" not in response.headers.get("Content-Type", ""):
+            logger.debug("Skipping non-HTML content at %s", url)
+            return None
+        return response.text
+
+    def _extract_internal_links(self, page_url: str, soup: BeautifulSoup) -> Iterator[str]:
+        for anchor in soup.find_all("a", href=True):
+            href = anchor.get("href")
+            if not href:
+                continue
+            absolute = urljoin(page_url, href)
+            if self._is_internal_url(absolute):
+                cleaned = self._normalize_url(absolute)
+                if cleaned:
+                    yield cleaned
+
+    def _extract_resources(
+        self, page_url: str, page_title: Optional[str], soup: BeautifulSoup
+    ) -> List[ResourceRecord]:
+        resources: List[ResourceRecord] = []
+        for anchor in soup.find_all("a", href=True):
+            href = anchor.get("href")
+            text = anchor.get_text(" ", strip=True)
+            if not href:
+                continue
+
+            resource_url = urljoin(page_url, href)
+            resource_type = self._classify_resource(resource_url, text)
+            if resource_type is None:
+                continue
+
+            description = self._derive_description(anchor)
+            record = ResourceRecord(
+                page_url=self._normalize_url(page_url),
+                resource_url=self._normalize_url(resource_url),
+                resource_title=text or (page_title or ""),
+                resource_type=resource_type,
+                page_title=page_title,
+                description=description,
+            )
+            if record not in resources:
+                resources.append(record)
+        return resources
+
+    # ------------------------------------------------------------------
+    def _classify_resource(self, resource_url: str, anchor_text: str) -> Optional[str]:
+        parsed = urlparse(resource_url)
+        if not parsed.scheme.startswith("http"):
+            return None
+
+        lower_path = parsed.path.lower()
+        for ext in self.RESOURCE_EXTENSIONS:
+            if lower_path.endswith(ext):
+                return ext.lstrip(".")
+
+        lower_text = (anchor_text or "").lower()
+        if any(keyword in lower_text for keyword in self.KEYWORD_HINTS):
+            if self._is_internal_url(resource_url):
+                return "page"
+        return None
+
+    @staticmethod
+    def _derive_description(anchor) -> Optional[str]:
+        """Attempt to capture a short description near the anchor."""
+        parent = anchor.find_parent(["p", "li", "div"])
+        if parent:
+            text = parent.get_text(" ", strip=True)
+            if text:
+                return text
+        return anchor.get_text(" ", strip=True) or None
+
+    def _is_internal_url(self, url: str) -> bool:
+        parsed = urlparse(url)
+        base = urlparse(self.base_url)
+        return parsed.netloc == base.netloc or (not parsed.netloc and parsed.path)
+
+    @staticmethod
+    def _normalize_url(url: str) -> str:
+        parsed = urlparse(url)
+        scheme = parsed.scheme or "https"
+        netloc = parsed.netloc
+        path = parsed.path or "/"
+        query = f"?{parsed.query}" if parsed.query else ""
+        fragment = ""
+        return f"{scheme}://{netloc}{path}{query}{fragment}" if netloc else url
+
+    @staticmethod
+    def _extract_page_title(soup: BeautifulSoup) -> Optional[str]:
+        if soup.title and soup.title.string:
+            return soup.title.string.strip()
+        return None
+
+    # ------------------------------------------------------------------
+    def to_dataframe(self, resources: Iterable[ResourceRecord]):
+        try:
+            import pandas as pd  # type: ignore
+        except ImportError as exc:  # pragma: no cover - pandas optional at runtime
+            raise RuntimeError(
+                "pandas is required to export resources to a dataframe"
+            ) from exc
+
+        data = [resource.as_dict() for resource in resources]
+        return pd.DataFrame(data)
+
+
+__all__ = ["BFSkinnerScraper", "ResourceRecord"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+beautifulsoup4>=4.14.2
+pandas>=2.3.3
+requests>=2.32.0

--- a/scrape.py
+++ b/scrape.py
@@ -1,0 +1,101 @@
+"""Command line entry point for scraping bfskinner.org free resources."""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import logging
+from pathlib import Path
+from typing import Iterable
+
+from bfskinner_scraper import BFSkinnerScraper
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Scrape free resources from https://www.bfskinner.org/",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("data/free_resources.csv"),
+        help="Path to the output CSV file (default: data/free_resources.csv)",
+    )
+    parser.add_argument(
+        "--json",
+        dest="json_output",
+        type=Path,
+        help="Optional path to export the data as JSON",
+    )
+    parser.add_argument(
+        "--max-pages",
+        type=int,
+        default=200,
+        help="Maximum number of pages to crawl (default: 200)",
+    )
+    parser.add_argument(
+        "--delay",
+        type=float,
+        default=0.5,
+        help="Delay between requests in seconds (default: 0.5)",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Logging level",
+    )
+    return parser.parse_args()
+
+
+def export_csv(path: Path, resources: Iterable[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    resources = list(resources)
+    if not resources:
+        logging.warning("No resources found; writing empty CSV to %s", path)
+    with path.open("w", newline="", encoding="utf-8") as csvfile:
+        writer = csv.DictWriter(
+            csvfile,
+            fieldnames=[
+                "page_url",
+                "page_title",
+                "resource_url",
+                "resource_title",
+                "resource_type",
+                "description",
+            ],
+        )
+        writer.writeheader()
+        writer.writerows(resources)
+
+
+def export_json(path: Path, resources: Iterable[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as jsonfile:
+        json.dump(list(resources), jsonfile, indent=2, ensure_ascii=False)
+
+
+def main() -> None:
+    args = parse_args()
+    logging.basicConfig(level=getattr(logging, args.log_level))
+
+    scraper = BFSkinnerScraper(
+        max_pages=args.max_pages,
+        request_delay=args.delay,
+    )
+
+    logging.info(
+        "Starting crawl of %s (max_pages=%s)", scraper.base_url, args.max_pages
+    )
+    resources = scraper.crawl()
+    resource_dicts = [record.as_dict() for record in resources]
+
+    export_csv(args.output, resource_dicts)
+    if args.json_output:
+        export_json(args.json_output, resource_dicts)
+
+    logging.info("Scraping complete. %s resources captured.", len(resource_dicts))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- introduce a BFS-based scraper that collects downloadable and keyword-tagged resources from bfskinner.org
- add a CLI entry point that exports discovered resources to CSV/JSON and document usage in the README
- capture runtime dependencies in requirements.txt

## Testing
- python -m compileall bfskinner_scraper scrape.py
- python scrape.py --max-pages 1 --delay 0 --output data/test.csv --log-level DEBUG *(fails in this environment because the proxy blocks access to bfskinner.org)*

------
https://chatgpt.com/codex/tasks/task_b_68e27c29ae3c8328a3f6af6f1c33b457