### PR TITLE
Add scraper implementation and comprehensive tests

### DIFF
--- a/bfskinner_scrape/__init__.py
+++ b/bfskinner_scrape/__init__.py
@@ -1,0 +1,5 @@
+"""Package providing tools to scrape B.F. Skinner related content."""
+
+from .scraper import ArticleRecord, Scraper, ScraperError
+
+__all__ = ["ArticleRecord", "Scraper", "ScraperError"]

--- a/bfskinner_scrape/scraper.py
+++ b/bfskinner_scrape/scraper.py
@@ -1,0 +1,198 @@
+"""Scraper implementation for B.F. Skinner related content."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+from urllib.parse import urljoin
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+
+
+DEFAULT_USER_AGENT = "BFSkinnerScraper/1.0"
+DEFAULT_TIMEOUT = 10
+
+
+class ScraperError(RuntimeError):
+    """Raised when the scraper cannot complete an operation."""
+
+
+@dataclass(frozen=True)
+class ArticleRecord:
+    """Represents a single article discovered by the scraper."""
+
+    title: str
+    url: str
+    summary: Optional[str] = None
+    published: Optional[str] = None
+
+
+class Scraper:
+    """High level interface to fetch and parse paginated article listings."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        opener: Optional[urllib.request.OpenerDirector] = None,
+        user_agent: str = DEFAULT_USER_AGENT,
+        timeout: int = DEFAULT_TIMEOUT,
+    ) -> None:
+        if not base_url:
+            raise ValueError("base_url must be provided")
+
+        self.base_url = base_url
+        self._opener = opener
+        self.headers = {"User-Agent": user_agent}
+        self.timeout = timeout
+
+    # ------------------------------------------------------------------
+    def scrape(self, *, start_url: Optional[str] = None) -> List[ArticleRecord]:
+        """Collect article records across any paginated listing pages.
+
+        Args:
+            start_url: Optional explicit starting URL. Defaults to ``base_url``.
+
+        Returns:
+            A list of :class:`ArticleRecord` objects sorted in the order the
+            articles were encountered.
+        """
+
+        next_page = start_url or self.base_url
+        visited_pages = set()
+        seen_articles = set()
+        collected: List[ArticleRecord] = []
+
+        while next_page and next_page not in visited_pages:
+            visited_pages.add(next_page)
+            html = self._fetch(next_page)
+            articles, possible_next = self.parse_listing(html)
+
+            for article in articles:
+                if article.url in seen_articles:
+                    continue
+                seen_articles.add(article.url)
+                collected.append(article)
+
+            if not possible_next or possible_next in visited_pages:
+                break
+            next_page = possible_next
+
+        return collected
+
+    # ------------------------------------------------------------------
+    def parse_listing(self, html: str) -> Tuple[List[ArticleRecord], Optional[str]]:
+        """Parse an article listing page and extract article metadata.
+
+        Args:
+            html: The raw HTML payload for a listing page.
+
+        Returns:
+            A tuple of ``(articles, next_url)`` where ``next_url`` is ``None``
+            when there is no pagination link.
+        """
+
+        root = self._parse_html(html)
+        articles = self._extract_articles(root)
+        next_url = self._find_next_link(root)
+        return articles, next_url
+
+    # ------------------------------------------------------------------
+    def _fetch(self, url: str) -> str:
+        """Retrieve HTML for the provided URL handling typical failures."""
+
+        request = urllib.request.Request(url, headers=self.headers)
+        opener = self._opener or urllib.request.build_opener()
+        # Cache the opener for subsequent requests so tests can introspect call data.
+        self._opener = opener
+
+        try:
+            with opener.open(request, timeout=self.timeout) as response:  # type: ignore[call-arg]
+                charset = response.headers.get_content_charset() if response.headers else None
+                encoding = charset or "utf-8"
+                payload = response.read()
+        except urllib.error.URLError as exc:  # pragma: no cover - integration detail
+            raise ScraperError(f"Failed to fetch URL: {url}") from exc
+
+        return payload.decode(encoding, errors="replace")
+
+    # ------------------------------------------------------------------
+    def _parse_html(self, html: str) -> ET.Element:
+        try:
+            return ET.fromstring(html)
+        except ET.ParseError as exc:
+            raise ScraperError("Unable to parse listing HTML") from exc
+
+    # ------------------------------------------------------------------
+    def _extract_articles(self, root: ET.Element) -> List[ArticleRecord]:
+        articles: List[ArticleRecord] = []
+        seen_urls = set()
+
+        for article_el in root.findall(".//article"):
+            title_el = article_el.find(".//h2")
+            link_el = None
+            if title_el is not None:
+                link_el = title_el.find(".//a")
+
+            if link_el is None:
+                continue
+
+            title = self._text_content(link_el) or self._text_content(title_el)
+            href = (link_el.get("href") or "").strip()
+
+            if not title or not href:
+                continue
+
+            url = urljoin(self.base_url, href)
+            if url in seen_urls:
+                continue
+            seen_urls.add(url)
+
+            summary_el = article_el.find(".//p")
+            summary = self._text_content(summary_el)
+
+            time_el = article_el.find(".//time")
+            published = None
+            if time_el is not None:
+                published = (time_el.get("datetime") or self._text_content(time_el)) or None
+
+            articles.append(
+                ArticleRecord(
+                    title=title,
+                    url=url,
+                    summary=summary or None,
+                    published=published,
+                )
+            )
+
+        return articles
+
+    # ------------------------------------------------------------------
+    def _find_next_link(self, root: ET.Element) -> Optional[str]:
+        for link in root.findall(".//a"):
+            rel = link.get("rel") or ""
+            classes = link.get("class") or ""
+            if self._contains_flag(rel, "next") or self._contains_flag(classes, "next"):
+                href = (link.get("href") or "").strip()
+                if href:
+                    return urljoin(self.base_url, href)
+        return None
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _contains_flag(attribute_value: str, flag: str) -> bool:
+        tokens = [token.strip().lower() for token in attribute_value.split() if token.strip()]
+        return flag.lower() in tokens
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _text_content(element: Optional[ET.Element]) -> str:
+        if element is None:
+            return ""
+        parts: List[str] = [element.text or ""]
+        for child in element:
+            parts.append(Scraper._text_content(child))
+            if child.tail:
+                parts.append(child.tail)
+        return "".join(parts).strip()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,0 +1,212 @@
+import pytest
+from unittest import mock
+import urllib.error
+
+from bfskinner_scrape import ArticleRecord, Scraper, ScraperError
+
+
+def make_http_response(html: str, *, charset: str = "utf-8"):
+    response = mock.Mock()
+    response.read.return_value = html.encode(charset)
+    response.headers = mock.Mock()
+    response.headers.get_content_charset.return_value = charset
+    response.__enter__ = mock.Mock(return_value=response)
+    response.__exit__ = mock.Mock(return_value=None)
+    return response
+
+
+def test_parse_listing_extracts_articles_and_next_link():
+    html = """
+    <html>
+        <body>
+            <section id="posts">
+                <article>
+                    <h2 class="entry-title"><a href="/article-1">The first article</a></h2>
+                    <time datetime="2020-01-01">January 1, 2020</time>
+                    <p class="excerpt">A short summary of the first piece.</p>
+                </article>
+                <article>
+                    <h2 class="entry-title"><a href="https://example.com/article-2">Second article</a></h2>
+                    <time datetime="2021-03-04">March 4, 2021</time>
+                    <p>Follow-up research and commentary.</p>
+                </article>
+            </section>
+            <nav class="pagination">
+                <a class="next" href="/page/2">Next page</a>
+            </nav>
+        </body>
+    </html>
+    """
+    scraper = Scraper("https://example.com")
+
+    articles, next_link = scraper.parse_listing(html)
+
+    assert articles == [
+        ArticleRecord(
+            title="The first article",
+            url="https://example.com/article-1",
+            summary="A short summary of the first piece.",
+            published="2020-01-01",
+        ),
+        ArticleRecord(
+            title="Second article",
+            url="https://example.com/article-2",
+            summary="Follow-up research and commentary.",
+            published="2021-03-04",
+        ),
+    ]
+    assert next_link == "https://example.com/page/2"
+
+
+@pytest.mark.parametrize(
+    "html",
+    [
+        "<html><body><article><h2>No link available</h2></article></body></html>",
+        "<html><body><article><h2><a>Missing href</a></h2></article></body></html>",
+    ],
+)
+def test_parse_listing_skips_incomplete_articles(html):
+    scraper = Scraper("https://example.com")
+
+    articles, next_link = scraper.parse_listing(html)
+
+    assert articles == []
+    assert next_link is None
+
+
+def test_parse_listing_rejects_invalid_html():
+    scraper = Scraper("https://example.com")
+
+    with pytest.raises(ScraperError):
+        scraper.parse_listing("<html><body><article>")
+
+
+def test_fetch_success():
+    opener = mock.Mock()
+    opener.open.return_value = make_http_response("<html></html>")
+    scraper = Scraper("https://example.com", opener=opener)
+
+    assert scraper._fetch("https://example.com/feed") == "<html></html>"
+
+    assert opener.open.call_count == 1
+    request_arg, kwargs = opener.open.call_args
+    assert request_arg[0].full_url == "https://example.com/feed"
+    headers = dict(request_arg[0].header_items())
+    assert headers.get("User-agent") == scraper.headers["User-Agent"]
+    assert kwargs["timeout"] == scraper.timeout
+
+
+def test_fetch_converts_url_errors():
+    opener = mock.Mock()
+    opener.open.side_effect = urllib.error.URLError("boom")
+    scraper = Scraper("https://example.com", opener=opener)
+
+    with pytest.raises(ScraperError):
+        scraper._fetch("https://example.com/feed")
+
+
+def test_fetch_wraps_http_error():
+    opener = mock.Mock()
+    opener.open.side_effect = urllib.error.HTTPError(
+        url="https://example.com/feed", code=500, msg="fail", hdrs=None, fp=None
+    )
+    scraper = Scraper("https://example.com", opener=opener)
+
+    with pytest.raises(ScraperError):
+        scraper._fetch("https://example.com/feed")
+
+
+def test_scrape_follows_pagination_and_deduplicates():
+    first_page = """
+    <html>
+        <body>
+            <article>
+                <h2><a href="/one">One</a></h2>
+                <time datetime="2020-01-01">January 1, 2020</time>
+                <p>First page summary.</p>
+            </article>
+            <a rel="next" href="/page/2">More</a>
+        </body>
+    </html>
+    """
+    second_page = """
+    <html>
+        <body>
+            <article>
+                <h2><a href="/one">One</a></h2>
+                <time datetime="2020-01-01">January 1, 2020</time>
+                <p>Duplicate item that should be ignored.</p>
+            </article>
+            <article>
+                <h2><a href="/two">Two</a></h2>
+                <p>Brand new content.</p>
+            </article>
+        </body>
+    </html>
+    """
+
+    opener = mock.Mock()
+    opener.open.side_effect = [
+        make_http_response(first_page),
+        make_http_response(second_page),
+    ]
+    scraper = Scraper("https://example.com", opener=opener)
+
+    records = scraper.scrape()
+
+    assert records == [
+        ArticleRecord(
+            title="One",
+            url="https://example.com/one",
+            summary="First page summary.",
+            published="2020-01-01",
+        ),
+        ArticleRecord(
+            title="Two",
+            url="https://example.com/two",
+            summary="Brand new content.",
+            published=None,
+        ),
+    ]
+    assert [call.args[0].full_url for call in opener.open.call_args_list] == [
+        "https://example.com",
+        "https://example.com/page/2",
+    ]
+    assert all(call.kwargs["timeout"] == scraper.timeout for call in opener.open.call_args_list)
+
+
+def test_scrape_stops_when_next_page_loops_back():
+    first_page = """
+    <html>
+        <body>
+            <article>
+                <h2><a href="/loop">Loop</a></h2>
+            </article>
+            <a class="next" href="/page/2">Next</a>
+        </body>
+    </html>
+    """
+    second_page = """
+    <html>
+        <body>
+            <article>
+                <h2><a href="/second">Second</a></h2>
+            </article>
+            <a class="next" href="/">Back</a>
+        </body>
+    </html>
+    """
+
+    opener = mock.Mock()
+    opener.open.side_effect = [
+        make_http_response(first_page),
+        make_http_response(second_page),
+    ]
+    scraper = Scraper("https://example.com/", opener=opener)
+
+    records = scraper.scrape()
+
+    assert [record.url for record in records] == [
+        "https://example.com/loop",
+        "https://example.com/second",
+    ]


### PR DESCRIPTION
## Summary
- implement a configurable scraper capable of fetching pages, parsing article listings, and following pagination
- expose the scraper package entry points for reuse
- build a pytest suite that exercises HTML parsing, pagination handling, network failures, and package import setup

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e2832f3bf4832895af2dd43dd5ef7e